### PR TITLE
Correct string comparison for course offerings

### DIFF
--- a/scrapers/src/uq.ts
+++ b/scrapers/src/uq.ts
@@ -19,7 +19,7 @@ const scraper: Scraper = {
             for (const tr of $coursePage(".offerings > tbody > tr").toArray()) {
                 // Cols: Course offerings, Location Mode, Course Profile
                 const tds = cheerio(tr).children("td").toArray();
-                if (cheerio(tds[0]).text().trim() === `Semester ${semester}, ${year}`) {
+                if (cheerio(tds[0]).text().trim().startsWith(`Semester ${semester}, ${year}`)) {
                     const url = cheerio(tds[3]).find('a').first().attr("href");
                     if (url) {
                         return url;


### PR DESCRIPTION
UQ recently changed how the course offerings are displayed breaking the string comparison. New format looks like

Semester 2, 2022 (25/07/2022 - 19/11/2022)

A starts with comparison should cover this.

Semester 2 data scrapping should work now